### PR TITLE
Transactional format script

### DIFF
--- a/scripts/clang_format_all.sh
+++ b/scripts/clang_format_all.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-SCRIPT_DIR=$(dirname $0)
-BASE_DIR=${PWD}/${SCRIPT_DIR}/..
+
+# we need to convert script dir to an absolute path
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=$(dirname $SCRIPT_DIR)
 
 find ${BASE_DIR} \( -path "${BASE_DIR}/src/*" -or -path "${BASE_DIR}/test/*" -or -path "${BASE_DIR}/tsl/*" \) \
     -and \( -name '*.c' -or -name '*.h' \) -print | xargs ${SCRIPT_DIR}/clang_format_wrapper.sh -style=file -i

--- a/scripts/clang_format_wrapper.sh
+++ b/scripts/clang_format_wrapper.sh
@@ -6,33 +6,77 @@
 # This script replaces PG_FUNCTION_ARGS with "PG_FUNCTION_ARGS fake_var_for_clang" to
 # make it look like a proper function for clang and then converts it back after clang runs.
 
-FILES="${@}"
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=$(dirname $SCRIPT_DIR)
+TEMP_DIR="/tmp/timescaledb_format"
+
+OPTIONS="${@}"
+
+if [ -e ${TEMP_DIR} ]
+then
+    echo "error: ${TEMP_DIR} already exists"
+    echo "       delete ${TEMP_DIR} to format"
+    exit 1
+fi
 
 cleanup() {
     echo "cleaning"
-    for opt in ${FILES}
-        do
-            if [[ "${opt:0:1}" != "-" ]]
-            then
-                sed -e 's/PG_FUNCTION_ARGS fake_var_for_clang/PG_FUNCTION_ARGS/' $opt > /tmp/replace
-                mv /tmp/replace $opt
-            fi
-        done
-    return
+    rm -rf ${TEMP_DIR}
 }
 
 trap cleanup EXIT SIGINT SIGTERM
 
-for opt in ${FILES}
+mkdir ${TEMP_DIR}
+if [[ $? != 0 ]]
+then
+    echo "error: could not create temporary directory ${TEMP_DIR}"
+    exit 1
+fi
+
+#from this point on, if we get a failure we end up in an invalid state, so exit
+set -e
+
+CLANG_FORMAT_FLAGS=""
+FILE_NAMES=""
+
+for opt in ${OPTIONS}
 do
     if [[ "${opt:0:1}" != "-" ]]
     then
-        # sed -i have different semantics on mac and linux, don't use
-        sed -e 's/(PG_FUNCTION_ARGS)/(PG_FUNCTION_ARGS fake_var_for_clang)/' $opt > /tmp/replace
-        mv /tmp/replace $opt
+        file_path=${opt#"$BASE_DIR/"}
+        FILE_NAMES="${FILE_NAMES} $file_path"
+    else
+        CLANG_FORMAT_FLAGS="${CLANG_FORMAT_FLAGS} $opt"
     fi
 done
 
-clang-format $@
+echo "copying to ${TEMP_DIR}"
+
+for name in ${FILE_NAMES}
+do
+    # sed -i have different semantics on mac and linux, don't use
+    mkdir -p $(dirname ${TEMP_DIR}/${name})
+    sed -e 's/(PG_FUNCTION_ARGS)/(PG_FUNCTION_ARGS fake_var_for_clang)/' ${BASE_DIR}/${name} > ${TEMP_DIR}/${name}
+done
+
+cp ${BASE_DIR}/.clang-format ${TEMP_DIR}/.clang-format
+
+CURR_DIR=${PWD}
+
+echo "formatting"
+
+cd ${TEMP_DIR}
+
+clang-format ${CLANG_FORMAT_FLAGS} ${FILE_NAMES}
+
+cd ${CURR_DIR}
+
+echo "copying back"
+
+for name in ${FILE_NAMES}
+do
+    sed -e 's/PG_FUNCTION_ARGS fake_var_for_clang/PG_FUNCTION_ARGS/' ${TEMP_DIR}/${name} > ${TEMP_DIR}/replace_file && \
+        mv ${TEMP_DIR}/replace_file ${BASE_DIR}/${name}
+done
 
 exit 0;


### PR DESCRIPTION
This version of the script copies all files to a temporary directory,
runs clang-format in the temp dir, and only then copies the files
back. This should prevent mis-fomratting when the script is cancled
in the middle of running.